### PR TITLE
Captcha support POC - DO NOT MERGE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 cache.json
 gui.ini
 **/__pycache__
@@ -6,3 +7,5 @@ gui.ini
 build/
 dist/
 TeslaPy.egg-info/
+tmpcaptcha.svg
+venv/

--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -65,16 +65,6 @@ logger.addHandler(logging.NullHandler())
 logger.addFilter(PasswdFilter())
 logging.getLogger('requests_oauthlib.oauth2_session').addFilter(PasswdFilter())
 
-import os, sys, subprocess
-
-# https://stackoverflow.com/questions/17317219/is-there-an-platform-independent-equivalent-of-os-startfile
-def open_file(filename):
-    if sys.platform == "win32":
-        os.startfile(filename)
-    else:
-        opener = "open" if sys.platform == "darwin" else "xdg-open"
-        subprocess.call([opener, filename])
-
 class Tesla(requests.Session):
     """ Implements a session manager for the Tesla Motors Owner API
 
@@ -178,9 +168,13 @@ class Tesla(requests.Session):
         form = HTMLForm(response.text)
         if 'captcha' in form.keys():
             import urllib.parse
+            import pathlib
+            import webbrowser
             captcharesp = oauth.get(urllib.parse.urljoin(response.url, "/captcha"))
-            open("tmpcaptcha.svg", "wb").write(captcharesp.content)
-            open_file("tmpcaptcha.svg")
+            captchpath = pathlib.Path("tmpcaptcha.svg")
+            captchpath.write_bytes(captcharesp.content)
+            print("Opening captcha SVG")
+            webbrowser.open("file://" + str(captchpath.absolute()))
             captcha = input("Enter captcha: ")
             form.update({'captcha': captcha})
 


### PR DESCRIPTION
Proof of concept - DO NOT MERGE.

This is a POC for captcha support. Not sure the best way to display the captcha, but it's a start to show how it could be done.

The captcha is an SVG, so not as wide support vs if it was a PNG.

The credential caching that's already there means that if you run `cli.py` (or `menu.py`) once, the `gui.py` and `menu.py` no longer require the captcha (at least for an hour or so).

See #20 for others with the same issue