### PR TITLE
Allow specifying the location of the cache file

### DIFF
--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -88,11 +88,13 @@ class Tesla(requests.Session):
     :param proxy: URL of proxy server.
     :param retry: Number of connection retries or :class:`Retry` instance.
     :param user_agent: The first piece of the User-Agent string.
+    :param cache_file: Relative or absolute path to json cache file.
     """
 
     def __init__(self, email, password, passcode_getter=None,
                  factor_selector=None, captcha_solver=None, verify=True,
-                 proxy=None, retry=0, user_agent=__name__ + '/' + __version__):
+                 proxy=None, retry=0, user_agent=__name__ + '/' + __version__,
+                 cache_file='cache.json'):
         super(Tesla, self).__init__()
         if not email:
             raise ValueError('`email` is not set')
@@ -101,6 +103,7 @@ class Tesla(requests.Session):
         self.passcode_getter = passcode_getter or self._get_passcode
         self.factor_selector = factor_selector or self._select_factor
         self.captcha_solver = captcha_solver or self._solve_captcha
+        self.cache_file = cache_file
         self.token = {}
         self.expires_at = 0
         self.authorized = False
@@ -292,9 +295,11 @@ class Tesla(requests.Session):
 
     def _token_updater(self):
         """ Handles token persistency """
+        if not self.cache_file:
+            return
         # Open cache file
         try:
-            with open('cache.json') as infile:
+            with open(self.cache_file) as infile:
                 cache = json.load(infile)
         except (IOError, ValueError):
             cache = {}
@@ -303,7 +308,7 @@ class Tesla(requests.Session):
             cache[self.email] = {'url': self.sso_base, 'sso': self.sso_token,
                                  SSO_CLIENT_ID: self.token}
             try:
-                with open('cache.json', 'w') as outfile:
+                with open(self.cache_file, 'w') as outfile:
                     json.dump(cache, outfile)
             except IOError:
                 logger.error('Cache not updated')


### PR DESCRIPTION
"cache.json" is a very generic name that may conflict with other
modules, and client code may want to select a different location
than the current directory too.