### PR TITLE
sentry mode does not exist in old Model S

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -298,7 +298,10 @@ class Dashboard(Frame):
         limit = ve['speed_limit_mode']['current_limit_mph']
         self.current_limit.text(app.vehicle.dist_units(limit, True))
         self.speed_limit_pin.text(str(ve['speed_limit_mode']['pin_code_set']))
-        self.sentry_mode.text(str(ve['sentry_mode']))
+        try:
+            self.sentry_mode.text(str(ve['sentry_mode']))
+        except:
+            self.sentry_mode.text('Does not exist')
         self.valet_mode.text(str(ve['valet_mode']))
         self.valet_pin.text(str(not 'valet_pin_needed' in ve))
         status = ve['software_update']['status'] or 'unavailable'

--- a/menu.py
+++ b/menu.py
@@ -38,10 +38,15 @@ def show_vehicle_data(vehicle):
     except GeocoderTimedOut as e:
         logging.error(e)
         location = coords
+    if cl['outside_temp'] is not None and cl['inside_temp'] is not None:
     # Climate state
-    fmt = 'Outside Temperature: {:17} Inside Temperature: {}'
-    print(fmt.format(vehicle.temp_units(cl['outside_temp']),
-                     vehicle.temp_units(cl['inside_temp'])))
+        fmt = 'Outside Temperature: {:17} Inside Temperature: {}'
+        print(fmt.format(vehicle.temp_units(cl['outside_temp']),
+                        vehicle.temp_units(cl['inside_temp'])))
+    else:
+        fmt = 'Outside Temperature: {:17} Inside Temperature: {}'
+        print(fmt.format('No reading avail','No reading avail'))
+
     fmt = 'Driver Temperature Setting: {:10} Passenger Temperature Setting: {}'
     print(fmt.format(vehicle.temp_units(cl['driver_temp_setting']),
                      vehicle.temp_units(cl['passenger_temp_setting'])))
@@ -76,8 +81,12 @@ def show_vehicle_data(vehicle):
     limit = vehicle.dist_units(ve['speed_limit_mode']['current_limit_mph'], True)
     print(fmt.format(str(ve['speed_limit_mode']['active']), limit))
     fmt = 'Speed Limit Pin Set: {:17} Sentry Mode: {}'
-    print(fmt.format(str(ve['speed_limit_mode']['pin_code_set']),
-                     str(ve['sentry_mode'])))
+    try:
+        print(fmt.format(str(ve['speed_limit_mode']['pin_code_set']),
+                         str(ve['sentry_mode'])))
+    except:
+        print(fmt.format(str(ve['speed_limit_mode']['pin_code_set']),
+                         'None'))
     fmt = 'Valet Mode: {:26} Valet Pin Set: {}'
     print(fmt.format(str(ve['valet_mode']), str(not 'valet_pin_needed' in ve)))
     print('-'*80)


### PR DESCRIPTION
With current code, the GUI python throws an error when trying to find the sentry mode for an older (2013) Model S. I just try/except around that issue. Could be more pythonic, but this does scratch the itch for now.