### PR TITLE
Document CHARGING_AMPS less than 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ These are the major commands:
 | CHANGE_CLIMATE_TEMPERATURE_SETTING | `driver_temp`, `passenger_temp` | temperature in celcius |
 | SCHEDULED_DEPARTURE <sup>1</sup> | `enable`, `departure_time`, `preconditioning_enabled`, `preconditioning_weekdays_only`, `off_peak_charging_enabled`, `off_peak_charging_weekdays_only`, `end_off_peak_time` | `true` or `false`, minutes past midnight |
 | SCHEDULED_CHARGING <sup>1</sup> | `enable`, `time` | `true` or `false`, minutes past midnight |
-| CHARGING_AMPS <sup>1</sup> | `charging_amps` | between 1-32 |
+| CHARGING_AMPS <sup>1</sup> | `charging_amps` | between 0-32 |
 | CHANGE_CHARGE_LIMIT | `percent` | percentage |
 | CHANGE_SUNROOF_STATE | `state` | `vent` or `close` |
 | WINDOW_CONTROL <sup>2</sup> | `command`, `lat`, `lon` | `vent` or `close`, `0`, `0` |


### PR DESCRIPTION
CHARGING_AMPS can be set to less than 5, by calling the API twice.

The first call sets it to 5, then the second call will set to the desired value less than 5.

This is useful for fine control matching solar production.