### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 def custom_auth(url):
-    with webdriver.Chrome() as browser:
+    options = webdriver.ChromeOptions()
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    with webdriver.Chrome(chrome_options=options) as browser:
         browser.get(url)
         WebDriverWait(browser, 300).until(EC.url_contains('void/callback'))
         return browser.current_url


### PR DESCRIPTION
Fixed the selenium example of browser interaction automation. Argument "--disable-blink-features=AutomationControlled" is introduced to prevent HTTP 403 Access Denied issues as a result of browser detection for Chrome browser windows triggered from selenium.