### PR TITLE
Preventive measure for browser automation detection (Chrome and Edge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 def custom_auth(url):
-    with webdriver.Chrome() as browser:
+    options = webdriver.ChromeOptions()
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    with webdriver.Chrome(chrome_options=options) as browser:
         browser.get(url)
         WebDriverWait(browser, 300).until(EC.url_contains('void/callback'))
         return browser.current_url

--- a/cli.py
+++ b/cli.py
@@ -33,8 +33,14 @@ def custom_auth(url):
         webview.start()
         return result[0]
     # Use selenium to control specified web browser
+    # Prevent Selenium from being detected (works for Chrome and Edge only, for now)
+    if args.web < 2:
+        options = [webdriver.chrome, webdriver.edge][args.web].options.Options()
+        options.add_argument("--disable-blink-features=AutomationControlled")
+    else:
+        options = None
     with [webdriver.Chrome, webdriver.Edge, webdriver.Firefox, webdriver.Opera,
-          webdriver.Safari][args.web]() as browser:
+          webdriver.Safari][args.web](options=options) as browser:
         logging.info('Selenium opened %s', browser.capabilities['browserName'])
         browser.get(url)
         WebDriverWait(browser, 300).until(EC.url_contains('void/callback'))

--- a/gui.py
+++ b/gui.py
@@ -662,9 +662,15 @@ class App(Tk):
             return pool.apply(show_webview, (url, ))  # Run in separate process
         # Use selenium if available and selected
         if webdriver and self.selenium.get():
+            # Prevent Selenium from being detected (works for Chrome and Edge only, for now)
+            if self.browser.get() < 2:
+                options = [webdriver.chrome, webdriver.edge][self.browser.get()].options.Options()
+                options.add_argument("--disable-blink-features=AutomationControlled")
+            else:
+                options = None
             with [webdriver.Chrome, webdriver.Edge,
                   webdriver.Firefox, webdriver.Opera,
-                  webdriver.Safari][self.browser.get()]() as browser:
+                  webdriver.Safari][self.browser.get()](options=options) as browser:
                 browser.get(url)
                 wait = WebDriverWait(browser, 300)
                 wait.until(EC.url_contains('void/callback'))

--- a/menu.py
+++ b/menu.py
@@ -280,8 +280,14 @@ def custom_auth(url):
         webview.start()
         return result[0]
     # Use selenium to control specified web browser
+    # Prevent Selenium from being detected (works for Chrome and Edge only, for now)
+    if args.web < 2:
+        options = [webdriver.chrome, webdriver.edge][args.web].options.Options()
+        options.add_argument("--disable-blink-features=AutomationControlled")
+    else:
+        options = None
     with [webdriver.Chrome, webdriver.Edge, webdriver.Firefox, webdriver.Opera,
-          webdriver.Safari][args.web]() as browser:
+          webdriver.Safari][args.web](options=options) as browser:
         logging.info('Selenium opened %s', browser.capabilities['browserName'])
         browser.get(url)
         WebDriverWait(browser, 300).until(EC.url_contains('void/callback'))


### PR DESCRIPTION
Added preventive measure for browser automation detection. Applies to Chrome and Edge for now. FireFox/Opera/Safari supportability needs more analysis as the measures are browser-specific.