### PR TITLE
Log cache file exception

### DIFF
--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -292,7 +292,9 @@ class Tesla(OAuth2Session):
         try:
             with open(self.cache_file) as infile:
                 cache = json.load(infile)
-        except (IOError, ValueError):
+        except (IOError, ValueError) as e:
+            logger.warning('Cannot load cache: %s',
+                           self.cache_file, exc_info=True)
             cache = {}
         return cache
 


### PR DESCRIPTION
Don't ignore cache file exceptions and log a warning instead.