### PR TITLE
Update response code check in command function to match latest Tesla API

### DIFF
--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -813,9 +813,11 @@ class Product(JsonDict):
     def command(self, name, **kwargs):
         """ Wrapper method for product command response error handling """
         response = self.api(name, **kwargs)['response']
-        if response['Code'] == 200:
+        if response.get('Code') == 200:
+            return response.get('Message')
+        elif response.get('code') == 201:
             return response.get('message')
-        raise ProductError(response.get('message'))
+        raise ProductError(response.get('Message') or response.get('message'))
 
 
 class BatteryTariffPeriodCost(

--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -813,7 +813,7 @@ class Product(JsonDict):
     def command(self, name, **kwargs):
         """ Wrapper method for product command response error handling """
         response = self.api(name, **kwargs)['response']
-        if response['code'] == 201:
+        if response['Code'] == 200:
             return response.get('message')
         raise ProductError(response.get('message'))
 

--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -811,14 +811,14 @@ class Product(JsonDict):
                         timezone=timezone)['response']
 
     def command(self, name, **kwargs):
-        """ Wrapper method for product command response error handling """
+        """" Wrapper method for product command response error handling """
         response = self.api(name, **kwargs)['response']
-        if response.get('Code') == 200:
-            return response.get('Message')
-        elif response.get('code') == 201:
-            return response.get('message')
-        raise ProductError(response.get('Message') or response.get('message'))
-
+        # Normalize keys to lowercase for case-insensitive lookup of items
+        r = {k.lower(): v for k, v in response.items()}
+        # Expect to receive a 200 or 201 code here, else raise error
+        if r.get('code') in (200, 201):
+            return r.get('message')
+        raise ProductError(response)
 
 class BatteryTariffPeriodCost(
         namedtuple('BatteryTariffPeriodCost', ['buy', 'sell', 'name'])):

--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -811,7 +811,7 @@ class Product(JsonDict):
                         timezone=timezone)['response']
 
     def command(self, name, **kwargs):
-        """" Wrapper method for product command response error handling """
+        """ Wrapper method for product command response error handling """
         response = self.api(name, **kwargs)['response']
         # Normalize keys to lowercase for case-insensitive lookup of items
         r = {k.lower(): v for k, v in response.items()}


### PR DESCRIPTION
The Tesla API appears to have been updated a few days ago and is returning a slightly different response than what TeslaPy is currently expecting. I have updated the response code check to match the latest Tesla API so it functions correctly.

I have tested this code working for controlling backup reserves and mode of a Powerwall 2, so there may be other cases to test before merging.