### PR TITLE
Fix 403 client error by enforcing TLS V1.3

### DIFF
--- a/teslapy/__init__.py
+++ b/teslapy/__init__.py
@@ -11,6 +11,7 @@ __version__ = '2.9.1'
 import os
 import ast
 import json
+import ssl
 import time
 import base64
 import hashlib
@@ -25,6 +26,7 @@ except ImportError:
     from urllib.parse import urljoin
 from collections import defaultdict, namedtuple
 import requests
+from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
 from requests.exceptions import *
 from requests.packages.urllib3.util.retry import Retry
@@ -49,6 +51,24 @@ try:
 except NameError:
     pass
 
+# Adapter to force TLS 1.3 only connections by Tesla's API servers. This is
+# required since June 2026 to avoid HTTPError: 403 Client Error: forbidden for
+# url: https://owner-api.teslamotors.com/api/1/products
+class TLSAdapter(HTTPAdapter):
+    def init_poolmanager(self, connections, maxsize, block=False, **kwargs):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        # Enforce minimum and maximum TLS versions
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+        ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+
+        # Pass the custom context to the base class
+        return super().init_poolmanager(
+            connections,
+            maxsize,
+            block,
+            ssl_context=ctx
+        )
 
 class Tesla(OAuth2Session):
     """ Implements a session manager for the Tesla Motors Owner API
@@ -97,7 +117,7 @@ class Tesla(OAuth2Session):
         self.auto_refresh_url = 'oauth2/v3/token'
         self.auto_refresh_kwargs = {'client_id': SSO_CLIENT_ID}
         self.token_updater = self._token_updater
-        self.mount('https://', requests.adapters.HTTPAdapter(max_retries=retry))
+        self.mount('https://', TLSAdapter(max_retries=retry))
         self.headers.update({'Content-Type': 'application/json',
                              'X-Tesla-User-Agent': app_user_agent,
                              'User-Agent': user_agent})


### PR DESCRIPTION
Since June 12th, 2026 the Tesla API is systematically rejecting requests.

This fix is the result of findings of the teslamate project (https://github.com/teslamate-org/teslamate/issues/5384).

It seems that tokens generated without TLS v1.3 are not considered valid for the owner API anymore.

Relevant logs:
  File "/home/jcompost/.local/lib/python3.9/site-packages/teslapy/__init__.py", line 375, in vehicle_list
  f) for v in self.api('PRODUCT_LIST')['response']]
  File "/home/jcompost/.local/lib/python3.9/site-packages/teslapy/__init__.py", line 369, in api
  dpoint['TYPE'], uri, serialize,
  File "/home/jcompost/.local/lib/python3.9/site-packages/teslapy/__init__.py", line 158, in request
  tus()  # Raise HTTPError, if one occurred
  File "/home/jcompost/.local/lib/python3.9/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
  requests.exceptions.HTTPError: 403 Client Error: forbidden, see https://developer.tesla.com/docs/fleet-api for url: https://owner-api.teslamotors.com/api/1/products